### PR TITLE
Feat/cancel button

### DIFF
--- a/app/(root)/posts/create-post/page.tsx
+++ b/app/(root)/posts/create-post/page.tsx
@@ -89,9 +89,22 @@ const CreatePost = () => {
           />
         </section>
 
-        <Button color="blue" type="submit">
-          {isSubmitting ? <Loader2 className="animate-spin" /> : "Create Post"}
-        </Button>
+        <div className="flex gap-x-4">
+          <Button
+            color="gray"
+            type="button"
+            onClick={() => router.push("/posts")}
+          >
+            Cancel
+          </Button>
+          <Button color="blue" type="submit">
+            {isSubmitting ? (
+              <Loader2 className="animate-spin" />
+            ) : (
+              "Create Post"
+            )}
+          </Button>
+        </div>
       </div>
     </form>
   );

--- a/components/post/Posts.tsx
+++ b/components/post/Posts.tsx
@@ -97,7 +97,7 @@ const Posts = ({
           ))
         ) : (
           <h3
-            className={`paragraph-1-regular text-white-300 bg-black-800 flex items-center justify-center rounded-md p-12`}
+            className={`paragraph-1-regular text-white-300 bg-black-800 flex w-full items-center justify-center rounded-md p-12`}
           >
             No posts to display!
           </h3>

--- a/components/post/UpdatePost.tsx
+++ b/components/post/UpdatePost.tsx
@@ -53,7 +53,7 @@ const UpdatePost = ({
     const postId = post.id;
     try {
       await updatePost(data, postId);
-      router.push("/");
+      router.push(`/posts/${postId}`);
     } catch (error) {
       console.log("error in catch", error);
       toast.error("Unable to create post");
@@ -86,9 +86,22 @@ const UpdatePost = ({
           />
         </section>
 
-        <Button color="blue" type="submit">
-          {isSubmitting ? <Loader2 className="animate-spin" /> : "Update Post"}
-        </Button>
+        <div className="flex gap-x-4">
+          <Button
+            color="gray"
+            type="button"
+            onClick={() => router.push(`/posts/${post.id}`)}
+          >
+            Cancel
+          </Button>
+          <Button color="blue" type="submit">
+            {isSubmitting ? (
+              <Loader2 className="animate-spin" />
+            ) : (
+              "Update Post"
+            )}
+          </Button>
+        </div>
       </div>
     </form>
   );

--- a/components/profile/EditProfile.tsx
+++ b/components/profile/EditProfile.tsx
@@ -75,13 +75,23 @@ const EditProfile = ({ user }: { user: User & { goals?: Goals[] } }) => {
           <Availability useFormHelpers={useFormHelpers} isEditProfile />
         </section>
 
-        <Button color="blue" type="submit">
-          {isSubmitting ? (
-            <Loader2 className="animate-spin" />
-          ) : (
-            "Update Profile"
-          )}
-        </Button>
+        <div className="flex gap-x-4">
+          <Button
+            color="gray"
+            type="button"
+            onClick={() => router.push("/profile")}
+          >
+            Cancel
+          </Button>
+
+          <Button color="blue" type="submit">
+            {isSubmitting ? (
+              <Loader2 className="animate-spin" />
+            ) : (
+              "Update Profile"
+            )}
+          </Button>
+        </div>
       </div>
     </form>
   );


### PR DESCRIPTION
### Issue
- Update & Create Post pages are missing 'Cancel' buttons
- Edit Profile page is missing 'Cancel' button
- When there are no posts to display, the text doesn't fill the whole section

### Updates
- Added 'Cancel' buttons and re-routed to either the `/posts/postId` `/posts` or `/profile`
- Added a `w-full` to the 'No posts to display' section