### PR TITLE
Feat: Edit/Create Post Mobile Responsiveness

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -178,6 +178,9 @@ input:-webkit-autofill:active {
 .tox-tbtn svg {
   fill: #adb3cc !important;
 }
+.tox-toolbar {
+  background-color: none !important;
+}
 .tox-toolbar-overlord {
   background-color: transparent !important;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -99,6 +99,19 @@
     @apply disabled:hover:bg-black-700 disabled:text-white-500 disabled:hover:text-white-500 disabled:bg-black-700;
   }
 
+  .resources-input-label {
+    @apply paragraph-3-regular bg-black-700 placeholder:text-white-500 w-full rounded-md border-none p-3 focus:outline-none;
+  }
+  .resources-input-link {
+    @apply paragraph-3-regular bg-black-700 placeholder:text-white-500 w-full rounded-md border-none p-3 focus:outline-none;
+  }
+  .resources-x-button {
+    @apply bg-black-700 h-11 rounded px-3;
+  }
+  .resources-x-icon {
+    @apply text-white-500 hover:text-white-300 hover:duration-300;
+  }
+
   /* Hide scrollbar for Chrome, Safari and Opera */
   .no-scrollbar::-webkit-scrollbar {
     display: none;

--- a/components/post/BasicInformationPost.tsx
+++ b/components/post/BasicInformationPost.tsx
@@ -5,6 +5,7 @@ import { Controller } from "react-hook-form";
 import { CreateType } from "@prisma/client";
 
 import { Input } from "@/components/shared/ui";
+import useInputBlurHandler from "@/lib/utils/useInputBlurHandler";
 import Learnings from "./Learnings";
 import CodeEditor from "./CodeEditor";
 import Steps from "./Steps";
@@ -32,10 +33,11 @@ const BasicInformationPost = ({
   const postType = watch("createType");
   const codeContent = watch("codeEditor");
   const { tags } = defaultValues;
+  useInputBlurHandler("title");
 
   return (
     <section className="space-y-6">
-      <h3 className="paragraph-3-medium mb-6 text-white-500">
+      <h3 className="paragraph-3-medium text-white-500 mb-6">
         BASIC INFORMATION
       </h3>
 
@@ -65,12 +67,12 @@ const BasicInformationPost = ({
 
       <Tags setValue={setValue} defaultValueTags={tags} />
 
-      <div className="flex flex-col text-white-300">
+      <div className="text-white-300 flex flex-col">
         <label className="paragraph-3-medium mb-2">
           Description <span className="font-light"> (required)</span>
         </label>
         <textarea
-          className="paragraph-3-regular rounded-md border-none bg-black-700 p-3"
+          className="paragraph-3-regular bg-black-700 rounded-md border-none p-3"
           placeholder="Enter a short description"
           {...register("description")}
         />

--- a/components/post/CreatePost.tsx
+++ b/components/post/CreatePost.tsx
@@ -91,14 +91,7 @@ const CreatePost = () => {
           />
         </section>
 
-        <div className="flex gap-x-4">
-          <Button
-            color="gray"
-            type="button"
-            onClick={() => router.push("/posts")}
-          >
-            Cancel
-          </Button>
+        <div className="max-xs-b:flex-col flex gap-4">
           <Button
             color="blue"
             type="submit"
@@ -111,6 +104,13 @@ const CreatePost = () => {
             ) : (
               "Create Post"
             )}
+          </Button>
+          <Button
+            color="gray"
+            type="button"
+            onClick={() => router.push("/posts")}
+          >
+            Cancel
           </Button>
         </div>
       </div>

--- a/components/post/Learnings.tsx
+++ b/components/post/Learnings.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
+import { CheckSquare, X } from "lucide-react";
 
 import { Button } from "@/components/shared/ui";
-import { CheckSquare, X } from "lucide-react";
+import useInputBlurHandler from "@/lib/utils/useInputBlurHandler";
 
 const Learnings = ({
   useFormHelpers,
@@ -30,6 +31,8 @@ const Learnings = ({
       : setIsDisabled(false);
   }, [fieldsInput, formState]);
 
+  useInputBlurHandler("learnings");
+
   return (
     <section className="space-y-6">
       <label className="paragraph-3-medium text-white-300">
@@ -38,12 +41,13 @@ const Learnings = ({
       {fields.map((field: { id: number }, index: number) => {
         return (
           <React.Fragment key={field.id}>
-            <div className="my-2 flex items-center justify-between bg-black-700 px-3 py-1">
+            <div className="bg-black-700 my-2 flex items-center justify-between px-3 py-1">
               <div className="flex items-center space-x-2">
                 <CheckSquare className="text-primary-500" size={16} />
               </div>
               <input
-                className="paragraph-3-regular placeholder:paragraph-3-regular ml-2 w-full rounded-md border-none bg-black-700 pl-1 text-white-100 placeholder:text-white-300 focus:outline-none"
+                id="learnings"
+                className="paragraph-3-regular placeholder:paragraph-3-regular bg-black-700 text-white-100 placeholder:text-white-300 ml-2 w-full rounded-md border-none pl-1 focus:outline-none"
                 placeholder="Enter what you've learned"
                 {...register(`learnings.${index}`)}
               />

--- a/components/post/ResourceFieldsMobile.tsx
+++ b/components/post/ResourceFieldsMobile.tsx
@@ -1,0 +1,63 @@
+import { X } from "lucide-react";
+import React from "react";
+
+type ResourceFieldType = {
+  errors: { resources: { label: { message: string } }[] };
+  index: number;
+  register: (type: string) => {};
+  remove: (index: number) => void;
+};
+
+const ResourceFieldsMobile = ({
+  errors,
+  index,
+  register,
+  remove,
+}: ResourceFieldType) => {
+  return (
+    <>
+      <div className="flex gap-x-2">
+        <div className="flex w-full flex-col">
+          <input
+            type="text"
+            className="paragraph-3-regular bg-black-700 placeholder:text-white-500 w-full rounded-md border-none p-3 focus:outline-none"
+            placeholder="Label"
+            {...register(`resources.${index}.label`)}
+          />
+
+          {errors.resources && errors.resources[index]?.label?.message && (
+            <span className="error-message">
+              {errors.resources[index].label.message}
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          className="bg-black-700 h-11 rounded px-3"
+          onClick={() => remove(index)}
+        >
+          <X
+            className="text-white-500 hover:text-white-300 hover:duration-300"
+            size={16}
+          />
+        </button>
+      </div>
+
+      <div className="flex w-full flex-col">
+        <input
+          type="text"
+          className="paragraph-3-regular bg-black-700 placeholder:text-white-500 w-full rounded-md border-none p-3 focus:outline-none"
+          placeholder="Resource Link"
+          {...register(`resources.${index}.link`)}
+        />
+        {errors.resources && errors.resources[index]?.link?.message && (
+          <span className="error-message">
+            {errors.resources[index].link.message}
+          </span>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default ResourceFieldsMobile;

--- a/components/post/ResourceFieldsMobile.tsx
+++ b/components/post/ResourceFieldsMobile.tsx
@@ -1,5 +1,6 @@
-import { X } from "lucide-react";
 import React from "react";
+import { X } from "lucide-react";
+import useInputBlurHandler from "@/lib/utils/useInputBlurHandler";
 
 type ResourceFieldType = {
   errors: {
@@ -19,11 +20,15 @@ const ResourceFieldsMobile = ({
   register,
   remove,
 }: ResourceFieldType) => {
+  useInputBlurHandler("label");
+  useInputBlurHandler("link");
+
   return (
     <>
       <div className="flex gap-x-2">
         <div className="flex w-full flex-col">
           <input
+            id="label"
             type="text"
             className="paragraph-3-regular bg-black-700 placeholder:text-white-500 w-full rounded-md border-none p-3 focus:outline-none"
             placeholder="Label"
@@ -50,6 +55,7 @@ const ResourceFieldsMobile = ({
 
       <div className="flex w-full flex-col">
         <input
+          id="link"
           type="text"
           className="paragraph-3-regular bg-black-700 placeholder:text-white-500 w-full rounded-md border-none p-3 focus:outline-none"
           placeholder="Resource Link"

--- a/components/post/ResourceFieldsMobile.tsx
+++ b/components/post/ResourceFieldsMobile.tsx
@@ -2,7 +2,12 @@ import { X } from "lucide-react";
 import React from "react";
 
 type ResourceFieldType = {
-  errors: { resources: { label: { message: string } }[] };
+  errors: {
+    resources: {
+      label: { message: string };
+      link: { message: string };
+    }[];
+  };
   index: number;
   register: (type: string) => {};
   remove: (index: number) => void;

--- a/components/post/ResourceFieldsMobile.tsx
+++ b/components/post/ResourceFieldsMobile.tsx
@@ -30,7 +30,7 @@ const ResourceFieldsMobile = ({
           <input
             id="label"
             type="text"
-            className="paragraph-3-regular bg-black-700 placeholder:text-white-500 w-full rounded-md border-none p-3 focus:outline-none"
+            className="resources-input-label"
             placeholder="Label"
             {...register(`resources.${index}.label`)}
           />
@@ -43,13 +43,10 @@ const ResourceFieldsMobile = ({
         </div>
         <button
           type="button"
-          className="bg-black-700 h-11 rounded px-3"
+          className="resources-x-button"
           onClick={() => remove(index)}
         >
-          <X
-            className="text-white-500 hover:text-white-300 hover:duration-300"
-            size={16}
-          />
+          <X className="resources-x-icon" size={16} />
         </button>
       </div>
 
@@ -57,7 +54,7 @@ const ResourceFieldsMobile = ({
         <input
           id="link"
           type="text"
-          className="paragraph-3-regular bg-black-700 placeholder:text-white-500 w-full rounded-md border-none p-3 focus:outline-none"
+          className="resources-input-link"
           placeholder="Resource Link"
           {...register(`resources.${index}.link`)}
         />

--- a/components/post/Resources.tsx
+++ b/components/post/Resources.tsx
@@ -21,19 +21,19 @@ const Resources = ({
 
   return (
     <section>
-      <div className="flex flex-col text-white-300">
+      <div className="text-white-300 flex flex-col">
         <h3 className="paragraph-3-medium text-white-500">RESOURCES & LINKS</h3>
       </div>
 
       <section className="mt-6">
         {fields.map((field: { id: number }, index: number) => {
           return (
-            <React.Fragment key={field.id}>
-              <div className="mb-2 flex gap-x-2">
+            <div key={field.id} className="mb-2 flex gap-x-2">
+              <div className="max-xs-b:hidden flex w-full gap-x-2">
                 <div className="flex w-full flex-col">
                   <input
                     type="text"
-                    className="paragraph-3-regular w-full rounded-md border-none bg-black-700 p-3 placeholder:text-white-500 focus:outline-none"
+                    className="paragraph-3-regular bg-black-700 placeholder:text-white-500 w-full rounded-md border-none p-3 focus:outline-none"
                     placeholder="Label"
                     {...register(`resources.${index}.label`)}
                   />
@@ -48,7 +48,7 @@ const Resources = ({
                 <div className="flex w-full flex-col">
                   <input
                     type="text"
-                    className="paragraph-3-regular w-full rounded-md border-none bg-black-700 p-3 placeholder:text-white-500 focus:outline-none"
+                    className="paragraph-3-regular bg-black-700 placeholder:text-white-500 w-full rounded-md border-none p-3 focus:outline-none"
                     placeholder="Resource Link"
                     {...register(`resources.${index}.link`)}
                   />
@@ -61,7 +61,7 @@ const Resources = ({
                 </div>
                 <button
                   type="button"
-                  className="h-11 rounded bg-black-700 px-3"
+                  className="bg-black-700 h-11 rounded px-3"
                   onClick={() => remove(index)}
                 >
                   <X
@@ -70,7 +70,51 @@ const Resources = ({
                   />
                 </button>
               </div>
-            </React.Fragment>
+
+              <div className="xs-b:hidden flex w-full flex-col gap-y-2">
+                <div className="flex gap-x-2">
+                  <div className="flex w-full flex-col">
+                    <input
+                      type="text"
+                      className="paragraph-3-regular bg-black-700 placeholder:text-white-500 w-full rounded-md border-none p-3 focus:outline-none"
+                      placeholder="Label"
+                      {...register(`resources.${index}.label`)}
+                    />
+
+                    {errors.resources &&
+                      errors.resources[index]?.label?.message && (
+                        <span className="error-message">
+                          {errors.resources[index].label.message}
+                        </span>
+                      )}
+                  </div>
+                  <button
+                    type="button"
+                    className="bg-black-700 h-11 rounded px-3"
+                    onClick={() => remove(index)}
+                  >
+                    <X
+                      className="text-white-500 hover:text-white-300 hover:duration-300"
+                      size={16}
+                    />
+                  </button>
+                </div>
+                <div className="flex w-full flex-col">
+                  <input
+                    type="text"
+                    className="paragraph-3-regular bg-black-700 placeholder:text-white-500 w-full rounded-md border-none p-3 focus:outline-none"
+                    placeholder="Resource Link"
+                    {...register(`resources.${index}.link`)}
+                  />
+                  {errors.resources &&
+                    errors.resources[index]?.link?.message && (
+                      <span className="error-message">
+                        {errors.resources[index].link.message}
+                      </span>
+                    )}
+                </div>
+              </div>
+            </div>
           );
         })}
       </section>

--- a/components/post/Resources.tsx
+++ b/components/post/Resources.tsx
@@ -3,6 +3,7 @@ import { X } from "lucide-react";
 
 import { Button } from "../shared";
 import ResourceFieldsMobile from "./ResourceFieldsMobile";
+import useInputBlurHandler from "@/lib/utils/useInputBlurHandler";
 
 const Resources = ({
   useFieldArray,
@@ -20,6 +21,9 @@ const Resources = ({
     control,
   });
 
+  useInputBlurHandler("label");
+  useInputBlurHandler("link");
+
   return (
     <section>
       <div className="text-white-300 flex flex-col">
@@ -33,6 +37,7 @@ const Resources = ({
               <div className="max-xs-b:hidden flex w-full gap-x-2">
                 <div className="flex w-full flex-col">
                   <input
+                    id="label"
                     type="text"
                     className="paragraph-3-regular bg-black-700 placeholder:text-white-500 w-full rounded-md border-none p-3 focus:outline-none"
                     placeholder="Label"
@@ -48,6 +53,7 @@ const Resources = ({
                 </div>
                 <div className="flex w-full flex-col">
                   <input
+                    id="link"
                     type="text"
                     className="paragraph-3-regular bg-black-700 placeholder:text-white-500 w-full rounded-md border-none p-3 focus:outline-none"
                     placeholder="Resource Link"

--- a/components/post/Resources.tsx
+++ b/components/post/Resources.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { X } from "lucide-react";
 
 import { Button } from "../shared";
+import ResourceFieldsMobile from "./ResourceFieldsMobile";
 
 const Resources = ({
   useFieldArray,
@@ -72,47 +73,12 @@ const Resources = ({
               </div>
 
               <div className="xs-b:hidden flex w-full flex-col gap-y-2">
-                <div className="flex gap-x-2">
-                  <div className="flex w-full flex-col">
-                    <input
-                      type="text"
-                      className="paragraph-3-regular bg-black-700 placeholder:text-white-500 w-full rounded-md border-none p-3 focus:outline-none"
-                      placeholder="Label"
-                      {...register(`resources.${index}.label`)}
-                    />
-
-                    {errors.resources &&
-                      errors.resources[index]?.label?.message && (
-                        <span className="error-message">
-                          {errors.resources[index].label.message}
-                        </span>
-                      )}
-                  </div>
-                  <button
-                    type="button"
-                    className="bg-black-700 h-11 rounded px-3"
-                    onClick={() => remove(index)}
-                  >
-                    <X
-                      className="text-white-500 hover:text-white-300 hover:duration-300"
-                      size={16}
-                    />
-                  </button>
-                </div>
-                <div className="flex w-full flex-col">
-                  <input
-                    type="text"
-                    className="paragraph-3-regular bg-black-700 placeholder:text-white-500 w-full rounded-md border-none p-3 focus:outline-none"
-                    placeholder="Resource Link"
-                    {...register(`resources.${index}.link`)}
-                  />
-                  {errors.resources &&
-                    errors.resources[index]?.link?.message && (
-                      <span className="error-message">
-                        {errors.resources[index].link.message}
-                      </span>
-                    )}
-                </div>
+                <ResourceFieldsMobile
+                  errors={errors}
+                  index={index}
+                  register={register}
+                  remove={remove}
+                />
               </div>
             </div>
           );

--- a/components/post/Resources.tsx
+++ b/components/post/Resources.tsx
@@ -39,7 +39,7 @@ const Resources = ({
                   <input
                     id="label"
                     type="text"
-                    className="paragraph-3-regular bg-black-700 placeholder:text-white-500 w-full rounded-md border-none p-3 focus:outline-none"
+                    className="resources-input-label"
                     placeholder="Label"
                     {...register(`resources.${index}.label`)}
                   />
@@ -55,7 +55,7 @@ const Resources = ({
                   <input
                     id="link"
                     type="text"
-                    className="paragraph-3-regular bg-black-700 placeholder:text-white-500 w-full rounded-md border-none p-3 focus:outline-none"
+                    className="resources-input-link"
                     placeholder="Resource Link"
                     {...register(`resources.${index}.link`)}
                   />
@@ -68,13 +68,10 @@ const Resources = ({
                 </div>
                 <button
                   type="button"
-                  className="bg-black-700 h-11 rounded px-3"
+                  className="resources-x-button"
                   onClick={() => remove(index)}
                 >
-                  <X
-                    className="text-white-500 hover:text-white-300 hover:duration-300"
-                    size={16}
-                  />
+                  <X className="resources-x-icon" size={16} />
                 </button>
               </div>
 

--- a/components/post/Steps.tsx
+++ b/components/post/Steps.tsx
@@ -2,8 +2,9 @@
 
 import React, { useEffect, useState } from "react";
 
-import { Button } from "@/components/shared/ui";
 import { CheckSquare, X } from "lucide-react";
+import { Button } from "@/components/shared/ui";
+import useInputBlurHandler from "@/lib/utils/useInputBlurHandler";
 
 const Steps = ({
   useFormHelpers,
@@ -30,6 +31,8 @@ const Steps = ({
       : setIsDisabled(false);
   }, [fieldsInput, formState]);
 
+  useInputBlurHandler("steps");
+
   return (
     <section className="space-y-6">
       <label className="paragraph-3-medium text-white-300">
@@ -38,12 +41,13 @@ const Steps = ({
       {fields.map((field: { id: number }, index: number) => {
         return (
           <React.Fragment key={field.id}>
-            <div className="my-2 flex items-center justify-between bg-black-700 px-3 py-1">
+            <div className="bg-black-700 my-2 flex items-center justify-between px-3 py-1">
               <div className="flex items-center space-x-2">
                 <CheckSquare className="text-primary-500" size={16} />
               </div>
               <input
-                className="paragraph-3-regular placeholder:paragraph-3-regular ml-2 w-full rounded-md border-none bg-black-700 pl-1 text-white-100 placeholder:text-white-300 focus:outline-none"
+                id="steps"
+                className="paragraph-3-regular placeholder:paragraph-3-regular bg-black-700 text-white-100 placeholder:text-white-300 ml-2 w-full rounded-md border-none pl-1 focus:outline-none"
                 placeholder="Enter a step"
                 {...register(`steps.${index}`)}
               />

--- a/components/post/Tags.tsx
+++ b/components/post/Tags.tsx
@@ -73,14 +73,14 @@ const Tags = ({
 
   return (
     <section className="space-y-6">
-      <div className="flex flex-col text-white-300">
+      <div className="text-white-300 flex flex-col">
         <label className="paragraph-3-medium mb-2">Tags</label>
-        <div className="relative flex w-full items-center gap-2 rounded-md border-none bg-black-700 px-2 focus:ring-1">
+        <div className="bg-black-700 relative flex w-full flex-wrap items-center gap-2 rounded-md border-none p-3 focus:ring-1">
           {tags.length > 0 &&
             tags.map((tag, idx) => (
               <span
                 key={idx}
-                className="paragraph-3-medium flex items-center gap-2 text-nowrap rounded-md bg-black-600 px-2"
+                className="paragraph-3-medium bg-black-600 flex items-center gap-2 text-nowrap rounded-md px-2"
               >
                 {tag}
                 <button type="button" onClick={() => handleDelete(tag)}>
@@ -92,7 +92,7 @@ const Tags = ({
               </span>
             ))}
           <input
-            className="paragraph-3-regular flex w-full border-none bg-transparent px-1 py-3 focus:ring-0"
+            className="paragraph-3-regular flex w-fit border-none bg-transparent px-1 py-0 focus:ring-0"
             type="text"
             id="tags"
             onChange={(event) => setTagInput(event.target.value)}

--- a/components/post/Tags.tsx
+++ b/components/post/Tags.tsx
@@ -92,7 +92,7 @@ const Tags = ({
               </span>
             ))}
           <input
-            className="paragraph-3-regular flex w-fit border-none bg-transparent px-1 py-0 focus:ring-0"
+            className="paragraph-3-regular flex min-w-[70px] grow basis-[70px] border-none bg-transparent px-1 py-0 focus:ring-0"
             type="text"
             id="tags"
             onChange={(event) => setTagInput(event.target.value)}

--- a/components/post/UpdatePost.tsx
+++ b/components/post/UpdatePost.tsx
@@ -89,14 +89,7 @@ const UpdatePost = ({
           />
         </section>
 
-        <div className="flex gap-x-4">
-          <Button
-            color="gray"
-            type="button"
-            onClick={() => router.push(`/posts/${post.id}`)}
-          >
-            Cancel
-          </Button>
+        <div className="max-xs-b:flex-col flex gap-4">
           <Button
             color="blue"
             type="submit"
@@ -109,6 +102,13 @@ const UpdatePost = ({
             ) : (
               "Update Post"
             )}
+          </Button>
+          <Button
+            color="gray"
+            type="button"
+            onClick={() => router.push(`/posts/${post.id}`)}
+          >
+            Cancel
           </Button>
         </div>
       </div>

--- a/components/shared/ui/Input.tsx
+++ b/components/shared/ui/Input.tsx
@@ -1,3 +1,4 @@
+import useInputBlurHandler from "@/lib/utils/useInputBlurHandler";
 import React, { forwardRef } from "react";
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
@@ -9,8 +10,10 @@ interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
 
 const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ label, id, placeholder, required = false, errors, ...rest }, ref) => {
+    useInputBlurHandler(id);
+
     return (
-      <div className=" flex flex-col text-white-300">
+      <div className=" text-white-300 flex flex-col">
         {label && (
           <label className="paragraph-3-medium mb-2">
             {label}
@@ -18,7 +21,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           </label>
         )}
         <input
-          className="paragraph-3-regular rounded-md border-none bg-black-700 p-3"
+          className="paragraph-3-regular bg-black-700 rounded-md border-none p-3"
           type="text"
           id={id}
           placeholder={placeholder}

--- a/lib/utils/useInputBlurHandler.ts
+++ b/lib/utils/useInputBlurHandler.ts
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+
+const useInputBlurHandler = (id: string) => {
+  useEffect(() => {
+    const onEnter = (event: KeyboardEvent) => {
+      if (event.key === "Enter" && document.activeElement?.id === id) {
+        event.preventDefault();
+        (document.activeElement as HTMLElement).blur();
+      }
+    };
+
+    window.addEventListener("keydown", onEnter);
+    return () => window.removeEventListener("keydown", onEnter);
+  }, [id]);
+};
+
+export default useInputBlurHandler;


### PR DESCRIPTION
### Issue
- Edit/Create Post page is not responsive for mobile screens
### Updates
- Vertically stacked 'Cancel' and 'Create Post'/'Update Post' buttons
- Vertically stacked each field in 'Resources & Links' and moved 'X' button to top of each set
- Ensured Tags input contained multiple tags within input field - flex wrap
- Ensured 'Add tags' input field shrank or grew in size per size of screen and space remaining in container
- Ensured that none of the inputs submitted form onEnter - created a custom onEnter hook shared across components